### PR TITLE
 Added S3 options to bucketWithLocal.

### DIFF
--- a/lib/bucket-with-local.js
+++ b/lib/bucket-with-local.js
@@ -7,7 +7,7 @@ const {
 } = require('./util');
 const UploadObjectCommand = require('./commands/upload-object-command');
 
-async function bucketWithLocal(localDir, bucketPrefix, options = {}) {
+async function bucketWithLocal(localDir, bucketPrefix, options = {}, s3Options = {}) {
     const {
         del = false,
         dryRun = false,
@@ -34,7 +34,7 @@ async function bucketWithLocal(localDir, bucketPrefix, options = {}) {
             maxConcurrentTransfers,
             monitor,
         });
-        pUpload = transferManager.upload(uploads);
+        pUpload = transferManager.upload(uploads, s3Options);
     }
     let pDelete;
     let deletions = [];

--- a/lib/transfer-manager.js
+++ b/lib/transfer-manager.js
@@ -57,7 +57,7 @@ class TransferManager {
         return status.currentCount;
     }
 
-    async upload(commands) {
+    async upload(commands, s3Options) {
         const status = new TransferStatus(commands);
         while (status.currentCount < status.totalCount) {
             const chunk = commands.slice(status.currentCount, status.currentCount + this.maxConcurrentTransfers);
@@ -77,11 +77,22 @@ class TransferManager {
                     stream.on('error', reject);
                     stream.on('end', resolve);
                 });
-                await this.client.send(new PutObjectCommand({
+                
+                let options = {
                     Bucket: bucket,
                     Key: key,
                     Body: stream,
-                }), { abortSignal: this.abortController.signal });
+                };
+
+                for(let [key, value] of Object.items(s3Options)) {
+                    if(typeof value === "function") {
+                        options[key] = value({Key: key});
+                    } else {
+                        options[key] = value
+                    }
+                }
+
+                await this.client.send(new PutObjectCommand(options), { abortSignal: this.abortController.signal });
                 return upload;
             }));
         }


### PR DESCRIPTION
I ran into an issue where I needed to add some more options to the PutObjectCommand, this pull request just allows those options to pass through to the PutObjectCommand call. If an option is a function, the function is called with the key name, otherwise it is passed straight through.

My issue in particular is that 

```aws s3 sync myFolder s3://my-bucket```

Automatically assigns a mime type in the metadata and also makes you the owner, so the PutObjectCommand needs to have this added to it:

```
{
  // ...
  ACL: "bucket-owner-full-control",
  Metadata: {
    ContentType: mime.lookup(Key) || "text/html",
  },
```

In particular this is for a bucket I use as a website, so without this added my website won't function.

I can use the new feature like this:

```
sync.bucketWithLocal(
    dir,
    process.env.REACT_APP_AWS_WEBSITE_BUCKET,
    {},
    {
      ACL: "bucket-owner-full-control",
      ContentType: ({ Key }: Partial<PutObjectCommandInput>) =>
        mime.lookup(Key || "") || "text/html",
    }
  );
```

Not sure this is the nicest API for this, but it solves my problem.