### PR TITLE
feat: add option to follow or not symlinks in local filesystems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 test/data
 test/multipart-data
 test/sync
+test/symlink-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [4.3.0]
 
-* implement follow symlinks and no follow symlinks options ([agouil](https://github.com/))
+* implement follow symlinks and no follow symlinks options ([agouil](https://github.com/agouil))
 
 ## [4.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.3.0]
+
+* implement follow symlinks and no follow symlinks options ([agouil](https://github.com/))
+
 ## [4.2.0]
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AWS CLI installation is **NOT** required by this module.
 - Sync a remote Amazon S3 bucket with a local file system (multipart uploads are supported)
 - Sync two remote Amazon S3 buckets
 - Sync only new and updated objects
-- Support AWS CLI options `--delete`, `--dryrun`, `--size-only`, `--include` and `--exclude`
+- Support AWS CLI options `--delete`, `--dryrun`, `--size-only`, `--include`, `--exclude`, `--follow-symlinks`, `--no-follow-symlinks`
 - Support AWS SDK native command input options
 - Monitor sync progress
 - Sync **any** number of objects (no 1000 objects limit)
@@ -222,6 +222,7 @@ Similar to AWS CLI ``aws s3 sync localDir bucketPrefix [options]``.
   - `del` *<boolean\>* Equivalent to CLI ``--delete`` option
   - `deleteExcluded` *<boolean\>* Delete **excluded** target objects even if they match a source object. Ignored if `del` is false. See [this](https://github.com/aws/aws-cli/issues/4923) CLI issue.
   - `sizeOnly` *<boolean\>* Equivalent to CLI ``--size-only`` option
+  - `followSymlinks` *<boolean\>* Equivalent to CLI ``--follow-symlinks`` option (default `true`)
   - `relocations` *<Relocation[]\>* Allows uploading objects to remote folders without mirroring the source directory structure. Each relocation is as a callback taking a string posix path param and returning a relocated string posix path.
   - `filters` *<Filter[]\>* [Almost](https://github.com/jeanbmar/s3-sync-client/issues/30) equivalent to CLI ``--exclude`` and ``--include`` options. Filters can be specified using plain objects including either an `include` or `exclude` property. The `include` and `exclude` properties are functions that take an object key and return a boolean.
   - `abortSignal` *<AbortSignal\>* Allows aborting the sync
@@ -246,6 +247,7 @@ Similar to AWS CLI ``aws s3 sync bucketPrefix localDir [options]``.
   - `del` *<boolean\>* Equivalent to CLI ``--delete`` option
   - `deleteExcluded` *<boolean\>* Delete **excluded** target objects even if they match a source object. Ignored if `del` is false. See [this](https://github.com/aws/aws-cli/issues/4923) CLI issue.
   - `sizeOnly` *<boolean\>* Equivalent to CLI ``--size-only`` option
+  - `followSymlinks` *<boolean\>* Equivalent to CLI ``--follow-symlinks`` option (default `true`)
   - `relocations` *<Relocation[]\>* Allows downloading objects to local directories without mirroring the source folder structure. Each relocation is as a callback taking a string posix path param and returning a relocated string posix path.
   - `filters` *<Filter[]\>* [Almost](https://github.com/jeanbmar/s3-sync-client/issues/30) equivalent to CLI ``--exclude`` and ``--include`` options. Filters can be specified using plain objects including either an `include` or `exclude` property. The `include` and `exclude` properties are functions that take an object key and return a boolean.
   - `abortSignal` *<AbortSignal\>* Allows aborting the sync

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ AWS CLI installation is **NOT** required by this module.
 - Sync a remote Amazon S3 bucket with a local file system (multipart uploads are supported)
 - Sync two remote Amazon S3 buckets
 - Sync only new and updated objects
-- Support AWS CLI options `--delete`, `--dryrun`, `--size-only`, `--include` and `--exclude`
+- Support AWS CLI options `--delete`, `--dryrun`, `--size-only`, `--include`, `--exclude`, `--follow-symlinks`, `--no-follow-symlinks`
 - Support AWS SDK native command input options
 - Monitor sync progress
 - Sync **any** number of objects (no 1000 objects limit)
@@ -224,6 +224,7 @@ Similar to AWS CLI ``aws s3 sync localDir bucketPrefix [options]``.
   - `del` *<boolean\>* Equivalent to CLI ``--delete`` option
   - `deleteExcluded` *<boolean\>* Delete **excluded** target objects even if they match a source object. Ignored if `del` is false. See [this](https://github.com/aws/aws-cli/issues/4923) CLI issue.
   - `sizeOnly` *<boolean\>* Equivalent to CLI ``--size-only`` option
+  - `followSymlinks` *<boolean\>* Equivalent to CLI ``--follow-symlinks`` option (default `true`)
   - `relocations` *<Relocation[]\>* Allows uploading objects to remote folders without mirroring the source directory structure. Each relocation is as a callback taking a string posix path param and returning a relocated string posix path.
   - `filters` *<Filter[]\>* [Almost](https://github.com/jeanbmar/s3-sync-client/issues/30) equivalent to CLI ``--exclude`` and ``--include`` options. Filters can be specified using plain objects including either an `include` or `exclude` property. The `include` and `exclude` properties are functions that take an object key and return a boolean.
   - `abortSignal` *<AbortSignal\>* Allows aborting the sync
@@ -248,6 +249,7 @@ Similar to AWS CLI ``aws s3 sync bucketPrefix localDir [options]``.
   - `del` *<boolean\>* Equivalent to CLI ``--delete`` option
   - `deleteExcluded` *<boolean\>* Delete **excluded** target objects even if they match a source object. Ignored if `del` is false. See [this](https://github.com/aws/aws-cli/issues/4923) CLI issue.
   - `sizeOnly` *<boolean\>* Equivalent to CLI ``--size-only`` option
+  - `followSymlinks` *<boolean\>* Equivalent to CLI ``--follow-symlinks`` option (default `true`)
   - `relocations` *<Relocation[]\>* Allows downloading objects to local directories without mirroring the source folder structure. Each relocation is as a callback taking a string posix path param and returning a relocated string posix path.
   - `filters` *<Filter[]\>* [Almost](https://github.com/jeanbmar/s3-sync-client/issues/30) equivalent to CLI ``--exclude`` and ``--include`` options. Filters can be specified using plain objects including either an `include` or `exclude` property. The `include` and `exclude` properties are functions that take an object key and return a boolean.
   - `abortSignal` *<AbortSignal\>* Allows aborting the sync

--- a/docs/classes/BucketObject.md
+++ b/docs/classes/BucketObject.md
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[src/fs/BucketObject.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/BucketObject.ts#L12)
+[src/fs/BucketObject.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/BucketObject.ts#L12)
 
 ## Properties
 
@@ -62,7 +62,7 @@
 
 #### Defined in
 
-[src/fs/BucketObject.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/BucketObject.ts#L9)
+[src/fs/BucketObject.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/BucketObject.ts#L9)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L21)
+[src/fs/SyncObject.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L21)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[src/fs/BucketObject.ts:10](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/BucketObject.ts#L10)
+[src/fs/BucketObject.ts:10](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/BucketObject.ts#L10)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L23)
+[src/fs/SyncObject.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L23)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L22)
+[src/fs/SyncObject.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L22)
 
 ## Accessors
 
@@ -132,7 +132,7 @@ SyncObject.isIncluded
 
 #### Defined in
 
-[src/fs/SyncObject.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L71)
+[src/fs/SyncObject.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L71)
 
 ## Methods
 
@@ -156,7 +156,7 @@ SyncObject.isIncluded
 
 #### Defined in
 
-[src/fs/SyncObject.ts:75](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L75)
+[src/fs/SyncObject.ts:75](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L75)
 
 ___
 
@@ -181,7 +181,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:86](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L86)
+[src/fs/SyncObject.ts:86](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L86)
 
 ___
 
@@ -205,7 +205,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:98](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L98)
+[src/fs/SyncObject.ts:98](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L98)
 
 ___
 
@@ -229,7 +229,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:106](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L106)
+[src/fs/SyncObject.ts:106](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L106)
 
 ___
 
@@ -255,4 +255,4 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L32)
+[src/fs/SyncObject.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L32)

--- a/docs/classes/CompleteMultipartLocalObjectCommand.md
+++ b/docs/classes/CompleteMultipartLocalObjectCommand.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L22)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L22)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:19](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L19)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:19](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L19)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L18)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L18)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L21)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L21)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L20)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L20)
 
 ## Methods
 
@@ -93,4 +93,4 @@ ___
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:29](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L29)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:29](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L29)

--- a/docs/classes/CopyBucketObjectCommand.md
+++ b/docs/classes/CopyBucketObjectCommand.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L26)
+[src/commands/CopyBucketObjectCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L26)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L22)
+[src/commands/CopyBucketObjectCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L22)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L20)
+[src/commands/CopyBucketObjectCommand.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L20)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L23)
+[src/commands/CopyBucketObjectCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L23)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L24)
+[src/commands/CopyBucketObjectCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L24)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L21)
+[src/commands/CopyBucketObjectCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L21)
 
 ## Methods
 
@@ -104,4 +104,4 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:34](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L34)
+[src/commands/CopyBucketObjectCommand.ts:34](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L34)

--- a/docs/classes/CopyBucketObjectsCommand.md
+++ b/docs/classes/CopyBucketObjectsCommand.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L30)
+[src/commands/CopyBucketObjectsCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L30)
 
 ## Properties
 
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L25)
+[src/commands/CopyBucketObjectsCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L25)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L23)
+[src/commands/CopyBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L23)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L26)
+[src/commands/CopyBucketObjectsCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L26)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L28)
+[src/commands/CopyBucketObjectsCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L28)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L27)
+[src/commands/CopyBucketObjectsCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L27)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L24)
+[src/commands/CopyBucketObjectsCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L24)
 
 ## Methods
 
@@ -115,4 +115,4 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L40)
+[src/commands/CopyBucketObjectsCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L40)

--- a/docs/classes/CreateMultipartLocalObjectUploadCommand.md
+++ b/docs/classes/CreateMultipartLocalObjectUploadCommand.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[src/commands/CreateMultipartLocalObjectUploadCommand.ts:19](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L19)
+[src/commands/CreateMultipartLocalObjectUploadCommand.ts:19](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L19)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[src/commands/CreateMultipartLocalObjectUploadCommand.ts:17](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L17)
+[src/commands/CreateMultipartLocalObjectUploadCommand.ts:17](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L17)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[src/commands/CreateMultipartLocalObjectUploadCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L18)
+[src/commands/CreateMultipartLocalObjectUploadCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L18)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[src/commands/CreateMultipartLocalObjectUploadCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L16)
+[src/commands/CreateMultipartLocalObjectUploadCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L16)
 
 ## Methods
 
@@ -82,4 +82,4 @@ ___
 
 #### Defined in
 
-[src/commands/CreateMultipartLocalObjectUploadCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L25)
+[src/commands/CreateMultipartLocalObjectUploadCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L25)

--- a/docs/classes/DeleteBucketObjectsCommand.md
+++ b/docs/classes/DeleteBucketObjectsCommand.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/commands/DeleteBucketObjectsCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DeleteBucketObjectsCommand.ts#L18)
+[src/commands/DeleteBucketObjectsCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DeleteBucketObjectsCommand.ts#L18)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[src/commands/DeleteBucketObjectsCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DeleteBucketObjectsCommand.ts#L15)
+[src/commands/DeleteBucketObjectsCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DeleteBucketObjectsCommand.ts#L15)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[src/commands/DeleteBucketObjectsCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DeleteBucketObjectsCommand.ts#L16)
+[src/commands/DeleteBucketObjectsCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DeleteBucketObjectsCommand.ts#L16)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[src/commands/DeleteBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DeleteBucketObjectsCommand.ts#L23)
+[src/commands/DeleteBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DeleteBucketObjectsCommand.ts#L23)

--- a/docs/classes/DownloadBucketObjectCommand.md
+++ b/docs/classes/DownloadBucketObjectCommand.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L32)
+[src/commands/DownloadBucketObjectCommand.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L32)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L28)
+[src/commands/DownloadBucketObjectCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L28)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L26)
+[src/commands/DownloadBucketObjectCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L26)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:29](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L29)
+[src/commands/DownloadBucketObjectCommand.ts:29](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L29)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L27)
+[src/commands/DownloadBucketObjectCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L27)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L30)
+[src/commands/DownloadBucketObjectCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L30)
 
 ## Methods
 
@@ -104,4 +104,4 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L40)
+[src/commands/DownloadBucketObjectCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L40)

--- a/docs/classes/DownloadBucketObjectsCommand.md
+++ b/docs/classes/DownloadBucketObjectsCommand.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:29](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L29)
+[src/commands/DownloadBucketObjectsCommand.ts:29](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L29)
 
 ## Properties
 
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L25)
+[src/commands/DownloadBucketObjectsCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L25)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L23)
+[src/commands/DownloadBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L23)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L26)
+[src/commands/DownloadBucketObjectsCommand.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L26)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L24)
+[src/commands/DownloadBucketObjectsCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L24)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L28)
+[src/commands/DownloadBucketObjectsCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L28)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L27)
+[src/commands/DownloadBucketObjectsCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L27)
 
 ## Methods
 
@@ -115,4 +115,4 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L39)
+[src/commands/DownloadBucketObjectsCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L39)

--- a/docs/classes/ListBucketObjectsCommand.md
+++ b/docs/classes/ListBucketObjectsCommand.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/commands/ListBucketObjectsCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListBucketObjectsCommand.ts#L18)
+[src/commands/ListBucketObjectsCommand.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListBucketObjectsCommand.ts#L18)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[src/commands/ListBucketObjectsCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListBucketObjectsCommand.ts#L15)
+[src/commands/ListBucketObjectsCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListBucketObjectsCommand.ts#L15)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[src/commands/ListBucketObjectsCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListBucketObjectsCommand.ts#L16)
+[src/commands/ListBucketObjectsCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListBucketObjectsCommand.ts#L16)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[src/commands/ListBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListBucketObjectsCommand.ts#L23)
+[src/commands/ListBucketObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListBucketObjectsCommand.ts#L23)

--- a/docs/classes/ListLocalObjectsCommand.md
+++ b/docs/classes/ListLocalObjectsCommand.md
@@ -11,6 +11,7 @@
 ### Properties
 
 - [directory](ListLocalObjectsCommand.md#directory)
+- [followSymlinks](ListLocalObjectsCommand.md#followsymlinks)
 
 ### Methods
 
@@ -31,7 +32,7 @@
 
 #### Defined in
 
-[src/commands/ListLocalObjectsCommand.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListLocalObjectsCommand.ts#L12)
+[src/commands/ListLocalObjectsCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListLocalObjectsCommand.ts#L15)
 
 ## Properties
 
@@ -41,7 +42,17 @@
 
 #### Defined in
 
-[src/commands/ListLocalObjectsCommand.ts:11](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListLocalObjectsCommand.ts#L11)
+[src/commands/ListLocalObjectsCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListLocalObjectsCommand.ts#L13)
+
+___
+
+### followSymlinks
+
+• **followSymlinks**: `boolean`
+
+#### Defined in
+
+[src/commands/ListLocalObjectsCommand.ts:14](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListLocalObjectsCommand.ts#L14)
 
 ## Methods
 
@@ -55,7 +66,7 @@
 
 #### Defined in
 
-[src/commands/ListLocalObjectsCommand.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListLocalObjectsCommand.ts#L16)
+[src/commands/ListLocalObjectsCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListLocalObjectsCommand.ts#L21)
 
 ___
 
@@ -75,4 +86,4 @@ ___
 
 #### Defined in
 
-[src/commands/ListLocalObjectsCommand.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListLocalObjectsCommand.ts#L20)
+[src/commands/ListLocalObjectsCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListLocalObjectsCommand.ts#L25)

--- a/docs/classes/LocalObject.md
+++ b/docs/classes/LocalObject.md
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[src/fs/LocalObject.ts:10](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/LocalObject.ts#L10)
+[src/fs/LocalObject.ts:10](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/LocalObject.ts#L10)
 
 ## Properties
 
@@ -65,7 +65,7 @@
 
 #### Defined in
 
-[src/fs/SyncObject.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L21)
+[src/fs/SyncObject.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L21)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L23)
+[src/fs/SyncObject.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L23)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[src/fs/LocalObject.ts:8](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/LocalObject.ts#L8)
+[src/fs/LocalObject.ts:8](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/LocalObject.ts#L8)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L22)
+[src/fs/SyncObject.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L22)
 
 ## Accessors
 
@@ -121,7 +121,7 @@ SyncObject.isIncluded
 
 #### Defined in
 
-[src/fs/SyncObject.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L71)
+[src/fs/SyncObject.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L71)
 
 ## Methods
 
@@ -145,7 +145,7 @@ SyncObject.isIncluded
 
 #### Defined in
 
-[src/fs/SyncObject.ts:75](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L75)
+[src/fs/SyncObject.ts:75](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L75)
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:86](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L86)
+[src/fs/SyncObject.ts:86](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L86)
 
 ___
 
@@ -194,7 +194,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:98](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L98)
+[src/fs/SyncObject.ts:98](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L98)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:106](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L106)
+[src/fs/SyncObject.ts:106](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L106)
 
 ___
 
@@ -244,4 +244,4 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L32)
+[src/fs/SyncObject.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L32)

--- a/docs/classes/S3SyncClient.md
+++ b/docs/classes/S3SyncClient.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/S3SyncClient.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/S3SyncClient.ts#L16)
+[src/S3SyncClient.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/S3SyncClient.ts#L16)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[src/S3SyncClient.ts:14](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/S3SyncClient.ts#L14)
+[src/S3SyncClient.ts:14](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/S3SyncClient.ts#L14)
 
 ## Methods
 
@@ -61,7 +61,7 @@
 
 #### Defined in
 
-[src/S3SyncClient.ts:33](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/S3SyncClient.ts#L33)
+[src/S3SyncClient.ts:33](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/S3SyncClient.ts#L33)
 
 ___
 
@@ -83,4 +83,4 @@ ___
 
 #### Defined in
 
-[src/S3SyncClient.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/S3SyncClient.ts#L21)
+[src/S3SyncClient.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/S3SyncClient.ts#L21)

--- a/docs/classes/SyncBucketWithBucketCommand.md
+++ b/docs/classes/SyncBucketWithBucketCommand.md
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:48](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L48)
+[src/commands/SyncBucketWithBucketCommand.ts:48](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L48)
 
 ## Properties
 
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:43](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L43)
+[src/commands/SyncBucketWithBucketCommand.ts:43](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L43)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:44](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L44)
+[src/commands/SyncBucketWithBucketCommand.ts:44](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L44)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L38)
+[src/commands/SyncBucketWithBucketCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L38)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L39)
+[src/commands/SyncBucketWithBucketCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L39)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L37)
+[src/commands/SyncBucketWithBucketCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L37)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L42)
+[src/commands/SyncBucketWithBucketCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L42)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:46](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L46)
+[src/commands/SyncBucketWithBucketCommand.ts:46](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L46)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:45](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L45)
+[src/commands/SyncBucketWithBucketCommand.ts:45](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L45)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:41](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L41)
+[src/commands/SyncBucketWithBucketCommand.ts:41](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L41)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L40)
+[src/commands/SyncBucketWithBucketCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L40)
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:35](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L35)
+[src/commands/SyncBucketWithBucketCommand.ts:35](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L35)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:36](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L36)
+[src/commands/SyncBucketWithBucketCommand.ts:36](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L36)
 
 ## Methods
 
@@ -181,4 +181,4 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:64](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L64)
+[src/commands/SyncBucketWithBucketCommand.ts:64](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L64)

--- a/docs/classes/SyncBucketWithLocalCommand.md
+++ b/docs/classes/SyncBucketWithLocalCommand.md
@@ -17,6 +17,7 @@
 - [deleteExcluded](SyncBucketWithLocalCommand.md#deleteexcluded)
 - [dryRun](SyncBucketWithLocalCommand.md#dryrun)
 - [filters](SyncBucketWithLocalCommand.md#filters)
+- [followSymlinks](SyncBucketWithLocalCommand.md#followsymlinks)
 - [localDir](SyncBucketWithLocalCommand.md#localdir)
 - [maxConcurrentTransfers](SyncBucketWithLocalCommand.md#maxconcurrenttransfers)
 - [monitor](SyncBucketWithLocalCommand.md#monitor)
@@ -42,7 +43,7 @@
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:63](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L63)
+[src/commands/SyncBucketWithLocalCommand.ts:66](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L66)
 
 ## Properties
 
@@ -52,7 +53,7 @@
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:55](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L55)
+[src/commands/SyncBucketWithLocalCommand.ts:58](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L58)
 
 ___
 
@@ -62,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:48](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L48)
+[src/commands/SyncBucketWithLocalCommand.ts:50](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L50)
 
 ___
 
@@ -72,7 +73,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:56](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L56)
+[src/commands/SyncBucketWithLocalCommand.ts:59](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L59)
 
 ___
 
@@ -82,7 +83,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:50](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L50)
+[src/commands/SyncBucketWithLocalCommand.ts:52](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L52)
 
 ___
 
@@ -92,7 +93,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:51](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L51)
+[src/commands/SyncBucketWithLocalCommand.ts:53](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L53)
 
 ___
 
@@ -102,7 +103,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:49](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L49)
+[src/commands/SyncBucketWithLocalCommand.ts:51](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L51)
 
 ___
 
@@ -112,7 +113,17 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:54](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L54)
+[src/commands/SyncBucketWithLocalCommand.ts:57](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L57)
+
+___
+
+### followSymlinks
+
+• **followSymlinks**: `boolean`
+
+#### Defined in
+
+[src/commands/SyncBucketWithLocalCommand.ts:55](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L55)
 
 ___
 
@@ -122,7 +133,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:47](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L47)
+[src/commands/SyncBucketWithLocalCommand.ts:49](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L49)
 
 ___
 
@@ -132,7 +143,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:60](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L60)
+[src/commands/SyncBucketWithLocalCommand.ts:63](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L63)
 
 ___
 
@@ -142,7 +153,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:59](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L59)
+[src/commands/SyncBucketWithLocalCommand.ts:62](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L62)
 
 ___
 
@@ -152,7 +163,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:61](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L61)
+[src/commands/SyncBucketWithLocalCommand.ts:64](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L64)
 
 ___
 
@@ -162,7 +173,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:53](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L53)
+[src/commands/SyncBucketWithLocalCommand.ts:56](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L56)
 
 ___
 
@@ -172,7 +183,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:52](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L52)
+[src/commands/SyncBucketWithLocalCommand.ts:54](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L54)
 
 ## Methods
 
@@ -192,4 +203,4 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:80](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L80)
+[src/commands/SyncBucketWithLocalCommand.ts:85](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L85)

--- a/docs/classes/SyncLocalWithBucketCommand.md
+++ b/docs/classes/SyncLocalWithBucketCommand.md
@@ -17,6 +17,7 @@
 - [deleteExcluded](SyncLocalWithBucketCommand.md#deleteexcluded)
 - [dryRun](SyncLocalWithBucketCommand.md#dryrun)
 - [filters](SyncLocalWithBucketCommand.md#filters)
+- [followSymlinks](SyncLocalWithBucketCommand.md#followsymlinks)
 - [localDir](SyncLocalWithBucketCommand.md#localdir)
 - [maxConcurrentTransfers](SyncLocalWithBucketCommand.md#maxconcurrenttransfers)
 - [monitor](SyncLocalWithBucketCommand.md#monitor)
@@ -41,7 +42,7 @@
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:50](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L50)
+[src/commands/SyncLocalWithBucketCommand.ts:53](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L53)
 
 ## Properties
 
@@ -51,7 +52,7 @@
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:45](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L45)
+[src/commands/SyncLocalWithBucketCommand.ts:48](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L48)
 
 ___
 
@@ -61,7 +62,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L37)
+[src/commands/SyncLocalWithBucketCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L39)
 
 ___
 
@@ -71,7 +72,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:46](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L46)
+[src/commands/SyncLocalWithBucketCommand.ts:49](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L49)
 
 ___
 
@@ -81,7 +82,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L40)
+[src/commands/SyncLocalWithBucketCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L42)
 
 ___
 
@@ -91,7 +92,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:41](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L41)
+[src/commands/SyncLocalWithBucketCommand.ts:43](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L43)
 
 ___
 
@@ -101,7 +102,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L39)
+[src/commands/SyncLocalWithBucketCommand.ts:41](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L41)
 
 ___
 
@@ -111,7 +112,17 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:44](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L44)
+[src/commands/SyncLocalWithBucketCommand.ts:47](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L47)
+
+___
+
+### followSymlinks
+
+• **followSymlinks**: `boolean`
+
+#### Defined in
+
+[src/commands/SyncLocalWithBucketCommand.ts:45](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L45)
 
 ___
 
@@ -121,7 +132,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L38)
+[src/commands/SyncLocalWithBucketCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L40)
 
 ___
 
@@ -131,7 +142,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:48](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L48)
+[src/commands/SyncLocalWithBucketCommand.ts:51](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L51)
 
 ___
 
@@ -141,7 +152,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:47](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L47)
+[src/commands/SyncLocalWithBucketCommand.ts:50](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L50)
 
 ___
 
@@ -151,7 +162,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:43](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L43)
+[src/commands/SyncLocalWithBucketCommand.ts:46](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L46)
 
 ___
 
@@ -161,7 +172,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L42)
+[src/commands/SyncLocalWithBucketCommand.ts:44](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L44)
 
 ## Methods
 
@@ -181,4 +192,4 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:66](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L66)
+[src/commands/SyncLocalWithBucketCommand.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L71)

--- a/docs/classes/SyncObject.md
+++ b/docs/classes/SyncObject.md
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[src/fs/SyncObject.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L26)
+[src/fs/SyncObject.ts:26](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L26)
 
 ## Properties
 
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[src/fs/SyncObject.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L21)
+[src/fs/SyncObject.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L21)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L24)
+[src/fs/SyncObject.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L24)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L23)
+[src/fs/SyncObject.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L23)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L22)
+[src/fs/SyncObject.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L22)
 
 ## Accessors
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L71)
+[src/fs/SyncObject.ts:71](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L71)
 
 ## Methods
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:75](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L75)
+[src/fs/SyncObject.ts:75](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L75)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:86](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L86)
+[src/fs/SyncObject.ts:86](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L86)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:98](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L98)
+[src/fs/SyncObject.ts:98](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L98)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:106](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L106)
+[src/fs/SyncObject.ts:106](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L106)
 
 ___
 
@@ -206,4 +206,4 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L32)
+[src/fs/SyncObject.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L32)

--- a/docs/classes/TransferMonitor.md
+++ b/docs/classes/TransferMonitor.md
@@ -64,7 +64,7 @@ EventEmitter.constructor
 
 #### Defined in
 
-[src/TransferMonitor.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L20)
+[src/TransferMonitor.ts:20](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L20)
 
 ## Properties
 
@@ -74,7 +74,7 @@ EventEmitter.constructor
 
 #### Defined in
 
-[src/TransferMonitor.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L18)
+[src/TransferMonitor.ts:18](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L18)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L16)
+[src/TransferMonitor.ts:16](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L16)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:17](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L17)
+[src/TransferMonitor.ts:17](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L17)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L15)
+[src/TransferMonitor.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L15)
 
 ___
 
@@ -345,7 +345,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L42)
+[src/TransferMonitor.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L42)
 
 ___
 
@@ -887,7 +887,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L27)
+[src/TransferMonitor.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L27)
 
 ___
 
@@ -907,7 +907,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L32)
+[src/TransferMonitor.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L32)
 
 ___
 
@@ -927,7 +927,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L37)
+[src/TransferMonitor.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L37)
 
 ___
 

--- a/docs/classes/UploadLocalObjectCommand.md
+++ b/docs/classes/UploadLocalObjectCommand.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L27)
+[src/commands/UploadLocalObjectCommand.ts:27](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L27)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L23)
+[src/commands/UploadLocalObjectCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L23)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L22)
+[src/commands/UploadLocalObjectCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L22)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L24)
+[src/commands/UploadLocalObjectCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L24)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L21)
+[src/commands/UploadLocalObjectCommand.ts:21](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L21)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L25)
+[src/commands/UploadLocalObjectCommand.ts:25](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L25)
 
 ## Methods
 
@@ -104,4 +104,4 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:34](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L34)
+[src/commands/UploadLocalObjectCommand.ts:34](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L34)

--- a/docs/classes/UploadLocalObjectPartCommand.md
+++ b/docs/classes/UploadLocalObjectPartCommand.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L39)
+[src/commands/UploadLocalObjectPartCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L39)
 
 ## Properties
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:36](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L36)
+[src/commands/UploadLocalObjectPartCommand.ts:36](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L36)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:35](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L35)
+[src/commands/UploadLocalObjectPartCommand.ts:35](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L35)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L38)
+[src/commands/UploadLocalObjectPartCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L38)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L32)
+[src/commands/UploadLocalObjectPartCommand.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L32)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L30)
+[src/commands/UploadLocalObjectPartCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L30)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L37)
+[src/commands/UploadLocalObjectPartCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L37)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:33](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L33)
+[src/commands/UploadLocalObjectPartCommand.ts:33](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L33)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:31](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L31)
+[src/commands/UploadLocalObjectPartCommand.ts:31](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L31)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:34](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L34)
+[src/commands/UploadLocalObjectPartCommand.ts:34](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L34)
 
 ## Methods
 
@@ -148,4 +148,4 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:51](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L51)
+[src/commands/UploadLocalObjectPartCommand.ts:51](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L51)

--- a/docs/classes/UploadLocalObjectsCommand.md
+++ b/docs/classes/UploadLocalObjectsCommand.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:46](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L46)
+[src/commands/UploadLocalObjectsCommand.ts:46](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L46)
 
 ## Properties
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L38)
+[src/commands/UploadLocalObjectsCommand.ts:38](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L38)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L37)
+[src/commands/UploadLocalObjectsCommand.ts:37](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L37)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L39)
+[src/commands/UploadLocalObjectsCommand.ts:39](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L39)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:36](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L36)
+[src/commands/UploadLocalObjectsCommand.ts:36](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L36)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:43](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L43)
+[src/commands/UploadLocalObjectsCommand.ts:43](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L43)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L42)
+[src/commands/UploadLocalObjectsCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L42)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:44](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L44)
+[src/commands/UploadLocalObjectsCommand.ts:44](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L44)
 
 ## Methods
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:78](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L78)
+[src/commands/UploadLocalObjectsCommand.ts:78](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L78)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:92](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L92)
+[src/commands/UploadLocalObjectsCommand.ts:92](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L92)
 
 ___
 
@@ -170,4 +170,4 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:57](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L57)
+[src/commands/UploadLocalObjectsCommand.ts:57](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L57)

--- a/docs/interfaces/ICommand.md
+++ b/docs/interfaces/ICommand.md
@@ -26,4 +26,4 @@
 
 #### Defined in
 
-[src/commands/Command.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/Command.ts#L32)
+[src/commands/Command.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/Command.ts#L32)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -85,7 +85,7 @@ Renames and re-exports [S3SyncClient](classes/S3SyncClient.md)
 
 #### Defined in
 
-[src/fs/BucketObject.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/BucketObject.ts#L3)
+[src/fs/BucketObject.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/BucketObject.ts#L3)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/commands/Command.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/Command.ts#L12)
+[src/commands/Command.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/Command.ts#L12)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[src/commands/CompleteMultipartLocalObjectCommand.ts:10](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CompleteMultipartLocalObjectCommand.ts#L10)
+[src/commands/CompleteMultipartLocalObjectCommand.ts:10](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CompleteMultipartLocalObjectCommand.ts#L10)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectCommand.ts:11](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectCommand.ts#L11)
+[src/commands/CopyBucketObjectCommand.ts:11](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectCommand.ts#L11)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[src/commands/CopyBucketObjectsCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CopyBucketObjectsCommand.ts#L13)
+[src/commands/CopyBucketObjectsCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CopyBucketObjectsCommand.ts#L13)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[src/commands/CreateMultipartLocalObjectUploadCommand.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L9)
+[src/commands/CreateMultipartLocalObjectUploadCommand.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/CreateMultipartLocalObjectUploadCommand.ts#L9)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[src/commands/DeleteBucketObjectsCommand.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DeleteBucketObjectsCommand.ts#L9)
+[src/commands/DeleteBucketObjectsCommand.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DeleteBucketObjectsCommand.ts#L9)
 
 ___
 
@@ -214,7 +214,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L9)
+[src/fs/SyncObject.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L9)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L15)
+[src/fs/SyncObject.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L15)
 
 ___
 
@@ -251,7 +251,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectCommand.ts:17](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectCommand.ts#L17)
+[src/commands/DownloadBucketObjectCommand.ts:17](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectCommand.ts#L17)
 
 ___
 
@@ -272,7 +272,7 @@ ___
 
 #### Defined in
 
-[src/commands/DownloadBucketObjectsCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/DownloadBucketObjectsCommand.ts#L13)
+[src/commands/DownloadBucketObjectsCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/DownloadBucketObjectsCommand.ts#L13)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[src/commands/Command.ts:7](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/Command.ts#L7)
+[src/commands/Command.ts:7](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/Command.ts#L7)
 
 ___
 
@@ -306,7 +306,7 @@ ___
 
 #### Defined in
 
-[src/commands/ListBucketObjectsCommand.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListBucketObjectsCommand.ts#L9)
+[src/commands/ListBucketObjectsCommand.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListBucketObjectsCommand.ts#L9)
 
 ___
 
@@ -319,10 +319,12 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `directory` | `string` |
+| `followSymlinks?` | `boolean` |
+| `noFollowSymlinks?` | `boolean` |
 
 #### Defined in
 
-[src/commands/ListLocalObjectsCommand.ts:6](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/ListLocalObjectsCommand.ts#L6)
+[src/commands/ListLocalObjectsCommand.ts:6](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/ListLocalObjectsCommand.ts#L6)
 
 ___
 
@@ -332,7 +334,7 @@ ___
 
 #### Defined in
 
-[src/fs/LocalObject.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/LocalObject.ts#L3)
+[src/fs/LocalObject.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/LocalObject.ts#L3)
 
 ___
 
@@ -342,7 +344,7 @@ ___
 
 #### Defined in
 
-[src/commands/Command.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/Command.ts#L3)
+[src/commands/Command.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/Command.ts#L3)
 
 ___
 
@@ -352,7 +354,7 @@ ___
 
 #### Defined in
 
-[src/S3SyncClient.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/S3SyncClient.ts#L9)
+[src/S3SyncClient.ts:9](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/S3SyncClient.ts#L9)
 
 ___
 
@@ -379,7 +381,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L13)
+[src/commands/SyncBucketWithBucketCommand.ts:13](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L13)
 
 ___
 
@@ -397,7 +399,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithBucketCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithBucketCommand.ts#L28)
+[src/commands/SyncBucketWithBucketCommand.ts:28](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithBucketCommand.ts#L28)
 
 ___
 
@@ -416,16 +418,18 @@ ___
 | `deleteExcluded?` | `boolean` |
 | `dryRun?` | `boolean` |
 | `filters?` | [`Filter`](modules.md#filter)[] |
+| `followSymlinks?` | `boolean` |
 | `localDir` | `string` |
 | `maxConcurrentTransfers?` | `number` |
 | `monitor?` | [`TransferMonitor`](classes/TransferMonitor.md) |
+| `noFollowSymlinks?` | `boolean` |
 | `partSize?` | `number` |
 | `relocations?` | [`Relocation`](modules.md#relocation)[] |
 | `sizeOnly?` | `boolean` |
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L22)
+[src/commands/SyncBucketWithLocalCommand.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L22)
 
 ___
 
@@ -443,7 +447,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncBucketWithLocalCommand.ts:40](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncBucketWithLocalCommand.ts#L40)
+[src/commands/SyncBucketWithLocalCommand.ts:42](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncBucketWithLocalCommand.ts#L42)
 
 ___
 
@@ -462,15 +466,17 @@ ___
 | `deleteExcluded?` | `boolean` |
 | `dryRun?` | `boolean` |
 | `filters?` | [`Filter`](modules.md#filter)[] |
+| `followSymlinks?` | `boolean` |
 | `localDir` | `string` |
 | `maxConcurrentTransfers?` | `number` |
 | `monitor?` | [`TransferMonitor`](classes/TransferMonitor.md) |
+| `noFollowSymlinks?` | `boolean` |
 | `relocations?` | [`Relocation`](modules.md#relocation)[] |
 | `sizeOnly?` | `boolean` |
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L15)
+[src/commands/SyncLocalWithBucketCommand.ts:15](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L15)
 
 ___
 
@@ -488,7 +494,7 @@ ___
 
 #### Defined in
 
-[src/commands/SyncLocalWithBucketCommand.ts:30](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/SyncLocalWithBucketCommand.ts#L30)
+[src/commands/SyncLocalWithBucketCommand.ts:32](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/SyncLocalWithBucketCommand.ts#L32)
 
 ___
 
@@ -506,7 +512,7 @@ ___
 
 #### Defined in
 
-[src/fs/SyncObject.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/fs/SyncObject.ts#L3)
+[src/fs/SyncObject.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/fs/SyncObject.ts#L3)
 
 ___
 
@@ -527,7 +533,7 @@ ___
 
 #### Defined in
 
-[src/TransferMonitor.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/TransferMonitor.ts#L3)
+[src/TransferMonitor.ts:3](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/TransferMonitor.ts#L3)
 
 ___
 
@@ -547,7 +553,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectCommand.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectCommand.ts#L12)
+[src/commands/UploadLocalObjectCommand.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectCommand.ts#L12)
 
 ___
 
@@ -571,7 +577,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L12)
+[src/commands/UploadLocalObjectPartCommand.ts:12](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L12)
 
 ___
 
@@ -593,7 +599,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectsCommand.ts#L23)
+[src/commands/UploadLocalObjectsCommand.ts:23](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectsCommand.ts#L23)
 
 ___
 
@@ -610,7 +616,7 @@ ___
 
 #### Defined in
 
-[src/commands/UploadLocalObjectPartCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/UploadLocalObjectPartCommand.ts#L24)
+[src/commands/UploadLocalObjectPartCommand.ts:24](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/UploadLocalObjectPartCommand.ts#L24)
 
 ## Functions
 
@@ -637,4 +643,4 @@ ___
 
 #### Defined in
 
-[src/commands/Command.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/8c597d9/src/commands/Command.ts#L22)
+[src/commands/Command.ts:22](https://github.com/jeanbmar/s3-sync-client/blob/c83b38d/src/commands/Command.ts#L22)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-sync-client",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "AWS CLI s3 sync for Node.js provides a modern client to perform S3 sync operations between file systems and S3 buckets in the spirit of the official AWS CLI command",
   "keywords": [
     "aws",

--- a/src/commands/ListLocalObjectsCommand.ts
+++ b/src/commands/ListLocalObjectsCommand.ts
@@ -5,27 +5,41 @@ import { LocalObject } from '../fs/LocalObject';
 
 export type ListLocalObjectsCommandInput = {
   directory: string;
+  followSymlinks: boolean;
 };
 
 export class ListLocalObjectsCommand {
   directory: string;
+  followSymlinks: boolean;
   constructor(input: ListLocalObjectsCommandInput) {
     this.directory = input.directory;
+    this.followSymlinks = input.followSymlinks;
   }
 
   async execute(): Promise<LocalObject[]> {
-    return this.listObjectsRecursively(this.directory);
+    return this.listObjectsRecursively(this.directory, this.followSymlinks);
   }
 
-  private async listObjectsRecursively(currentDir): Promise<LocalObject[]> {
+  private async listObjectsRecursively(
+    currentDir,
+    followSymlinks
+  ): Promise<LocalObject[]> {
     let objects: LocalObject[] = [];
     const childPaths = await fsp.readdir(currentDir);
     // eslint-disable-next-line no-restricted-syntax
     for (const childPath of childPaths) {
       const filePath = path.join(currentDir, childPath);
-      const stats = await fsp.stat(filePath);
+      const stats = await fsp.lstat(filePath);
+      if (stats.isSymbolicLink() && !followSymlinks) {
+        // eslint-disable-next-line no-continue
+        continue;
+      } else if (stats.isSymbolicLink()) {
+        await fsp.stat(filePath);
+      }
       if (stats.isDirectory()) {
-        objects = objects.concat(await this.listObjectsRecursively(filePath));
+        objects = objects.concat(
+          await this.listObjectsRecursively(filePath, followSymlinks)
+        );
       } else {
         const id = toPosixPath(path.relative(this.directory, filePath));
         objects.push(

--- a/src/commands/SyncBucketWithLocalCommand.ts
+++ b/src/commands/SyncBucketWithLocalCommand.ts
@@ -26,6 +26,7 @@ export type SyncBucketWithLocalCommandInput = {
   del?: boolean;
   deleteExcluded?: boolean;
   sizeOnly?: boolean;
+  followSymlinks?: boolean;
   relocations?: Relocation[];
   filters?: Filter[];
   abortSignal?: AbortSignal;
@@ -50,6 +51,7 @@ export class SyncBucketWithLocalCommand {
   del: boolean;
   deleteExcluded: boolean;
   sizeOnly: boolean;
+  followSymlinks: boolean;
   relocations: Relocation[];
   filters: Filter[];
   abortSignal?: AbortSignal;
@@ -67,6 +69,7 @@ export class SyncBucketWithLocalCommand {
     this.del = input.del ?? false;
     this.deleteExcluded = input.deleteExcluded ?? false;
     this.sizeOnly = input.sizeOnly ?? false;
+    this.followSymlinks = input.followSymlinks ?? true;
     this.relocations = input.relocations ?? [];
     this.filters = input.filters ?? [];
     this.abortSignal = input.abortSignal;
@@ -80,7 +83,10 @@ export class SyncBucketWithLocalCommand {
   async execute(client: S3Client): Promise<SyncBucketWithLocalCommandOutput> {
     const { bucket, prefix } = parsePrefix(this.bucketPrefix);
     const [sourceObjects, targetObjects] = await Promise.all([
-      new ListLocalObjectsCommand({ directory: this.localDir }).execute(),
+      new ListLocalObjectsCommand({
+        directory: this.localDir,
+        followSymlinks: this.followSymlinks,
+      }).execute(),
       new ListBucketObjectsCommand({ bucket, prefix }).execute(client),
     ]);
     if (prefix !== '')

--- a/src/commands/SyncBucketWithLocalCommand.ts
+++ b/src/commands/SyncBucketWithLocalCommand.ts
@@ -27,6 +27,7 @@ export type SyncBucketWithLocalCommandInput = {
   deleteExcluded?: boolean;
   sizeOnly?: boolean;
   followSymlinks?: boolean;
+  noFollowSymlinks?: boolean;
   relocations?: Relocation[];
   filters?: Filter[];
   abortSignal?: AbortSignal;
@@ -69,7 +70,8 @@ export class SyncBucketWithLocalCommand {
     this.del = input.del ?? false;
     this.deleteExcluded = input.deleteExcluded ?? false;
     this.sizeOnly = input.sizeOnly ?? false;
-    this.followSymlinks = input.followSymlinks ?? true;
+    const noFollowSymlinks = input.noFollowSymlinks ?? false;
+    this.followSymlinks = input.followSymlinks ?? !noFollowSymlinks;
     this.relocations = input.relocations ?? [];
     this.filters = input.filters ?? [];
     this.abortSignal = input.abortSignal;

--- a/src/commands/SyncLocalWithBucketCommand.ts
+++ b/src/commands/SyncLocalWithBucketCommand.ts
@@ -19,6 +19,7 @@ export type SyncLocalWithBucketCommandInput = {
   del?: boolean;
   deleteExcluded?: boolean;
   sizeOnly?: boolean;
+  followSymlinks?: boolean;
   relocations?: Relocation[];
   filters?: Filter[];
   abortSignal?: AbortSignal;
@@ -40,6 +41,7 @@ export class SyncLocalWithBucketCommand {
   del: boolean;
   deleteExcluded: boolean;
   sizeOnly: boolean;
+  followSymlinks: boolean;
   relocations: Relocation[];
   filters: Filter[];
   abortSignal?: AbortSignal;
@@ -54,6 +56,7 @@ export class SyncLocalWithBucketCommand {
     this.del = input.del ?? false;
     this.deleteExcluded = input.deleteExcluded ?? false;
     this.sizeOnly = input.sizeOnly ?? false;
+    this.followSymlinks = input.followSymlinks ?? true;
     this.relocations = input.relocations ?? [];
     this.filters = input.filters ?? [];
     this.abortSignal = input.abortSignal;
@@ -68,7 +71,10 @@ export class SyncLocalWithBucketCommand {
     await fsp.mkdir(this.localDir, { recursive: true });
     const [sourceObjects, targetObjects] = await Promise.all([
       new ListBucketObjectsCommand({ bucket, prefix }).execute(client),
-      new ListLocalObjectsCommand({ directory: this.localDir }).execute(),
+      new ListLocalObjectsCommand({
+        directory: this.localDir,
+        followSymlinks: this.followSymlinks,
+      }).execute(),
     ]);
     if (prefix !== '')
       this.relocations = [

--- a/src/commands/SyncLocalWithBucketCommand.ts
+++ b/src/commands/SyncLocalWithBucketCommand.ts
@@ -20,6 +20,7 @@ export type SyncLocalWithBucketCommandInput = {
   deleteExcluded?: boolean;
   sizeOnly?: boolean;
   followSymlinks?: boolean;
+  noFollowSymlinks?: boolean;
   relocations?: Relocation[];
   filters?: Filter[];
   abortSignal?: AbortSignal;
@@ -56,7 +57,8 @@ export class SyncLocalWithBucketCommand {
     this.del = input.del ?? false;
     this.deleteExcluded = input.deleteExcluded ?? false;
     this.sizeOnly = input.sizeOnly ?? false;
-    this.followSymlinks = input.followSymlinks ?? true;
+    const noFollowSymlinks = input.noFollowSymlinks ?? false;
+    this.followSymlinks = input.followSymlinks ?? !noFollowSymlinks;
     this.relocations = input.relocations ?? [];
     this.filters = input.filters ?? [];
     this.abortSignal = input.abortSignal;

--- a/test/S3SyncClient.test.ts
+++ b/test/S3SyncClient.test.ts
@@ -27,7 +27,7 @@ import {
   SyncObject,
   ListBucketObjectsCommand,
   ListLocalObjectsCommand,
-} from '../src';
+} from '..';
 
 const BUCKET = 's3-sync-client';
 const BUCKET_2 = 's3-sync-client-2';
@@ -80,7 +80,6 @@ test('s3 sync client', async (t) => {
       const objects = await syncClient.send(
         new ListLocalObjectsCommand({
           directory: path.join(DATA_DIR, 'def/jkl'),
-          followSymlinks: true,
         })
       );
       assert.deepStrictEqual(
@@ -99,7 +98,6 @@ test('s3 sync client', async (t) => {
         syncClient.send(
           new ListLocalObjectsCommand({
             directory: path.join(DATA_DIR, 'xoin'),
-            followSymlinks: true,
           })
         )
       );
@@ -112,10 +110,7 @@ test('s3 sync client', async (t) => {
           followSymlinks: false,
         })
       );
-      assert.equal(
-        objects.find((id: string) => id === 'valid'),
-        undefined
-      );
+      assert(!hasObject(objects, 'valid'));
     });
 
     await l.test('throws if symlink is broken', async () => {
@@ -133,14 +128,9 @@ test('s3 sync client', async (t) => {
       const objects = await syncClient.send(
         new ListLocalObjectsCommand({
           directory: path.join(SYMLINK_DATA_DIR, 'valid-symlinks'),
-          followSymlinks: true,
         })
       );
-      const object = objects.find(({ id }) => id === 'valid');
-      assert.equal(
-        object.path,
-        path.join(SYMLINK_DATA_DIR, 'valid-symlinks/valid')
-      );
+      assert(hasObject(objects, 'valid'));
     });
   });
 
@@ -506,7 +496,6 @@ test('s3 sync client', async (t) => {
       const objects = await syncClient.send(
         new ListLocalObjectsCommand({
           directory: SYNC_DIR,
-          followSymlinks: true,
         })
       );
       assert(hasObject(objects, 'jkl/xmoj') === true);
@@ -539,7 +528,6 @@ test('s3 sync client', async (t) => {
         const objects = await syncClient.send(
           new ListLocalObjectsCommand({
             directory: `${SYNC_DIR}/issue9`,
-            followSymlinks: true,
           })
         );
         assert(objects.length === 11);
@@ -565,7 +553,6 @@ test('s3 sync client', async (t) => {
       const objects = await syncClient.send(
         new ListLocalObjectsCommand({
           directory: SYNC_DIR,
-          followSymlinks: true,
         })
       );
       assert(hasObject(objects, 'xmoj') === true);
@@ -586,7 +573,6 @@ test('s3 sync client', async (t) => {
         const objects = await syncClient.send(
           new ListLocalObjectsCommand({
             directory: SYNC_DIR,
-            followSymlinks: true,
           })
         );
         assert(count === 5000);
@@ -610,7 +596,6 @@ test('s3 sync client', async (t) => {
         const objects = await syncClient.send(
           new ListLocalObjectsCommand({
             directory: SYNC_DIR,
-            followSymlinks: true,
           })
         );
         assert(objects.length === 5000);
@@ -667,7 +652,6 @@ test('s3 sync client', async (t) => {
       const objects = await syncClient.send(
         new ListLocalObjectsCommand({
           directory: path.join(SYNC_DIR, 'issue40'),
-          followSymlinks: true,
         })
       );
       assert(hasObject(objects, 'def/jkl/xmoj') === false);
@@ -816,7 +800,6 @@ test('s3 sync client', async (t) => {
         const objects = await syncClient.send(
           new ListLocalObjectsCommand({
             directory: path.join(SYNC_DIR, 'def/jkl'),
-            followSymlinks: true,
           })
         );
         assert(objects.length === 11);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -19,3 +19,22 @@ export const createMultipartLocalObjects = async (dir) => {
     Buffer.alloc(512 * 1024 * 1024).fill('a')
   );
 };
+
+export const createSymlinkDataObjects = async (dir) => {
+  fs.rmSync(dir, { force: true, recursive: true });
+
+  const validSymlinksPath = path.join(dir, 'valid-symlinks');
+  fs.mkdirSync(validSymlinksPath, { recursive: true });
+  fs.writeFileSync(path.join(validSymlinksPath, 'some-file'), 'this is a test');
+  fs.symlinkSync(
+    path.join(validSymlinksPath, 'some-file'),
+    path.join(validSymlinksPath, 'valid')
+  );
+
+  const brokenSymlinksPath = path.join(dir, 'broken-symlinks');
+  fs.mkdirSync(brokenSymlinksPath, { recursive: true });
+  fs.symlinkSync(
+    path.join(brokenSymlinksPath, 'some-other-file'),
+    path.join(brokenSymlinksPath, 'broken')
+  );
+};


### PR DESCRIPTION
Adds an option to the client to follow or not follow symlinks in the local filesystem during a sync command. 

This is behaving similar to how the AWS CLI behaves if the `--no-follow-symlinks` option is passed. 
By default the client will follow symlinks.

This is addressing [this issue](https://github.com/jeanbmar/s3-sync-client/issues/51) of skipping broken symlinks during a local to bucket sync. 