### PR TITLE
Fix named import of S3Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AWS CLI installation is **NOT** required by this module.
 ``S3SyncClient`` is a wrapper for the AWS SDK ``S3Client`` class.
 
 ```javascript
-import S3Client from '@aws-sdk/client-s3';
+import { S3Client } from '@aws-sdk/client-s3';
 import { S3SyncClient } from 's3-sync-client';
 
 const s3Client = new S3Client({ /* ... */ });

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ AWS CLI installation is **NOT** required by this module.
 ``S3SyncClient`` is a wrapper for the AWS SDK ``S3Client`` class.
 
 ```javascript
-import S3Client from '@aws-sdk/client-s3';
+import { S3Client } from '@aws-sdk/client-s3';
 import { S3SyncClient } from 's3-sync-client';
 
 const s3Client = new S3Client({ /* ... */ });


### PR DESCRIPTION
Super minor thing, but I got a bit confused by an error in the example code due missing brackets to make the import of the `S3Client` a named one.

Example of the named import e.g. in the official example code: https://www.npmjs.com/package/@aws-sdk/client-s3