### PR TITLE
Fix key not found on bucket syncs when a filename contain special characters …

### DIFF
--- a/src/commands/CopyBucketObjectCommand.ts
+++ b/src/commands/CopyBucketObjectCommand.ts
@@ -36,7 +36,7 @@ export class CopyBucketObjectCommand {
       {
         Bucket: this.targetBucket,
         Key: this.bucketObject.id,
-        CopySource: encodeURI(
+        CopySource: encodeURIComponent(
           `${this.bucketObject.bucket}/${this.bucketObject.key}`
         ),
       },


### PR DESCRIPTION
…like + , ? , / etc

Reference of similar issue in git hub. 
https://github.com/aws/aws-sdk-js-v3/issues/5475